### PR TITLE
Allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "psr/http-message": "^1.0.1"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^1.7",
-        "nyholm/psr7": "^1.3",
+        "guzzlehttp/psr7": "dev-master",
         "phpstan/phpstan": "~0.12.31",
         "phpstan/phpstan-phpunit": "~0.12.11",
         "phpunit/phpunit": "~8.5.8 || ~9.2.2",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "monolog/monolog": "^2.0",
         "psr/http-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.7",
+        "nyholm/psr7": "^1.3",
         "phpstan/phpstan": "~0.12.31",
         "phpstan/phpstan-phpunit": "~0.12.11",
         "phpunit/phpunit": "~8.5.8 || ~9.2.2",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "psr/http-message": "^1.0.1"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "dev-master",
+        "guzzlehttp/psr7": "^1.7",
+        "nyholm/psr7": "^1.3",
         "phpstan/phpstan": "~0.12.31",
         "phpstan/phpstan-phpunit": "~0.12.11",
         "phpunit/phpunit": "~8.5.8 || ~9.2.2",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "psr/http-message": "^1.0.1"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "dev-master",
+        "guzzlehttp/psr7": "^1.7",
         "phpstan/phpstan": "~0.12.31",
         "phpstan/phpstan-phpunit": "~0.12.11",
         "phpunit/phpunit": "~8.5.8 || ~9.2.2",

--- a/tests/Unit/Cube/CubeHandlerTest.php
+++ b/tests/Unit/Cube/CubeHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Cube;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\HttpFactory;
 use Monolog\Logger;
 use MonologHttp\Cube\CubeHandler;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -30,7 +30,7 @@ final class CubeHandlerTest extends TestCase
         parent::setUp();
         $this->httpClient = $this->createMock(ClientInterface::class);
         $this->logger = new Logger('test');
-        $this->logger->pushHandler(new CubeHandler($this->httpClient, new Psr17Factory(), 'www.mydomain.com'));
+        $this->logger->pushHandler(new CubeHandler($this->httpClient, new HttpFactory(), 'www.mydomain.com'));
     }
 
     /**

--- a/tests/Unit/Cube/CubeHandlerTest.php
+++ b/tests/Unit/Cube/CubeHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Cube;
 
-use GuzzleHttp\Psr7\HttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Monolog\Logger;
 use MonologHttp\Cube\CubeHandler;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -30,7 +30,7 @@ final class CubeHandlerTest extends TestCase
         parent::setUp();
         $this->httpClient = $this->createMock(ClientInterface::class);
         $this->logger = new Logger('test');
-        $this->logger->pushHandler(new CubeHandler($this->httpClient, new HttpFactory(), 'www.mydomain.com'));
+        $this->logger->pushHandler(new CubeHandler($this->httpClient, new Psr17Factory(), 'www.mydomain.com'));
     }
 
     /**

--- a/tests/Unit/Flowdock/FlowdockHandlerTest.php
+++ b/tests/Unit/Flowdock/FlowdockHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Flowdock;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Uri;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Logger;
@@ -31,7 +31,7 @@ final class FlowdockHandlerTest extends TestCase
         parent::setUp();
         $this->client = $this->createMock(ClientInterface::class);
         $uri = new Uri('https://api.example.com/messages');
-        $this->handler = new FlowdockHandler($this->client, new Psr17Factory(), $uri, 'asecretflowtoken');
+        $this->handler = new FlowdockHandler($this->client, new HttpFactory(), $uri, 'asecretflowtoken');
     }
 
     /**

--- a/tests/Unit/Flowdock/FlowdockHandlerTest.php
+++ b/tests/Unit/Flowdock/FlowdockHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Flowdock;
 
-use GuzzleHttp\Psr7\HttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use GuzzleHttp\Psr7\Uri;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Logger;
@@ -31,7 +31,7 @@ final class FlowdockHandlerTest extends TestCase
         parent::setUp();
         $this->client = $this->createMock(ClientInterface::class);
         $uri = new Uri('https://api.example.com/messages');
-        $this->handler = new FlowdockHandler($this->client, new HttpFactory(), $uri, 'asecretflowtoken');
+        $this->handler = new FlowdockHandler($this->client, new Psr17Factory(), $uri, 'asecretflowtoken');
     }
 
     /**

--- a/tests/Unit/Gitlab/GitlabHandlerTest.php
+++ b/tests/Unit/Gitlab/GitlabHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Gitlab;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\HttpFactory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Gitlab\GitlabHandler;
 use MonologHttp\Tests\Unit\HandlerTestCase;
@@ -40,7 +40,7 @@ final class GitlabHandlerTest extends HandlerTestCase
     {
         return new GitlabHandler(
             $this->httpClient,
-            new Psr17Factory(),
+            new HttpFactory(),
             'www.gitlab.com',
             'authkey'
         );

--- a/tests/Unit/Gitlab/GitlabHandlerTest.php
+++ b/tests/Unit/Gitlab/GitlabHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Gitlab;
 
-use GuzzleHttp\Psr7\HttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Gitlab\GitlabHandler;
 use MonologHttp\Tests\Unit\HandlerTestCase;
@@ -40,7 +40,7 @@ final class GitlabHandlerTest extends HandlerTestCase
     {
         return new GitlabHandler(
             $this->httpClient,
-            new HttpFactory(),
+            new Psr17Factory(),
             'www.gitlab.com',
             'authkey'
         );

--- a/tests/Unit/Gitter/GitterHandlerTest.php
+++ b/tests/Unit/Gitter/GitterHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Gitter;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\HttpFactory;
 use Monolog\Logger;
 use MonologHttp\Gitter\GitterHandler;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -33,7 +33,7 @@ final class GitterHandlerTest extends TestCase
         $this->logger->pushHandler(
             new GitterHandler(
                 $this->httpClient,
-                new Psr17Factory(),
+                new HttpFactory(),
                 'chat_id',
                 'key'
             )

--- a/tests/Unit/Gitter/GitterHandlerTest.php
+++ b/tests/Unit/Gitter/GitterHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Gitter;
 
-use GuzzleHttp\Psr7\HttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Monolog\Logger;
 use MonologHttp\Gitter\GitterHandler;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -33,7 +33,7 @@ final class GitterHandlerTest extends TestCase
         $this->logger->pushHandler(
             new GitterHandler(
                 $this->httpClient,
-                new HttpFactory(),
+                new Psr17Factory(),
                 'chat_id',
                 'key'
             )

--- a/tests/Unit/Mandrill/MandrillHandlerTest.php
+++ b/tests/Unit/Mandrill/MandrillHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Mandrill;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\HttpFactory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Mandrill\MandrillHandler;
 use MonologHttp\Tests\Unit\HandlerTestCase;
@@ -43,7 +43,7 @@ final class MandrillHandlerTest extends HandlerTestCase
     {
         return new MandrillHandler(
             $this->httpClient,
-            new Psr17Factory(),
+            new HttpFactory(),
             'apiuser',
             new \Swift_Message()
         );

--- a/tests/Unit/Mandrill/MandrillHandlerTest.php
+++ b/tests/Unit/Mandrill/MandrillHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Mandrill;
 
-use GuzzleHttp\Psr7\HttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Mandrill\MandrillHandler;
 use MonologHttp\Tests\Unit\HandlerTestCase;
@@ -43,7 +43,7 @@ final class MandrillHandlerTest extends HandlerTestCase
     {
         return new MandrillHandler(
             $this->httpClient,
-            new HttpFactory(),
+            new Psr17Factory(),
             'apiuser',
             new \Swift_Message()
         );

--- a/tests/Unit/Sendgrid/SendGridHandlerTest.php
+++ b/tests/Unit/Sendgrid/SendGridHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Sendgrid;
 
-use GuzzleHttp\Psr7\HttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Sendgrid\SendGridHandler;
 use MonologHttp\Tests\Unit\HandlerTestCase;
@@ -39,7 +39,7 @@ final class SendGridHandlerTest extends HandlerTestCase
     {
         return new SendGridHandler(
             $this->httpClient,
-            new HttpFactory(),
+            new Psr17Factory(),
             'apiuser',
             'apikey',
             'from@domain.com',

--- a/tests/Unit/Sendgrid/SendGridHandlerTest.php
+++ b/tests/Unit/Sendgrid/SendGridHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Sendgrid;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\HttpFactory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Sendgrid\SendGridHandler;
 use MonologHttp\Tests\Unit\HandlerTestCase;
@@ -39,7 +39,7 @@ final class SendGridHandlerTest extends HandlerTestCase
     {
         return new SendGridHandler(
             $this->httpClient,
-            new Psr17Factory(),
+            new HttpFactory(),
             'apiuser',
             'apikey',
             'from@domain.com',

--- a/tests/Unit/Sentry/SentryHandlerTest.php
+++ b/tests/Unit/Sentry/SentryHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Sentry;
 
-use GuzzleHttp\Psr7\HttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use GuzzleHttp\Psr7\Uri;
 use Monolog\Logger;
 use MonologHttp\Sentry\SentryHandler;
@@ -33,7 +33,7 @@ final class SentryHandlerTest extends TestCase
         $uri = new Uri('https://b70a3:b7d80@sentry.example.com/1/api/1/store');
         $handler = new SentryHandler(
             $this->client,
-            new HttpFactory(),
+            new Psr17Factory(),
             $uri,
             'sentryKey'
         );

--- a/tests/Unit/Sentry/SentryHandlerTest.php
+++ b/tests/Unit/Sentry/SentryHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Sentry;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Uri;
 use Monolog\Logger;
 use MonologHttp\Sentry\SentryHandler;
@@ -33,7 +33,7 @@ final class SentryHandlerTest extends TestCase
         $uri = new Uri('https://b70a3:b7d80@sentry.example.com/1/api/1/store');
         $handler = new SentryHandler(
             $this->client,
-            new Psr17Factory(),
+            new HttpFactory(),
             $uri,
             'sentryKey'
         );

--- a/tests/Unit/Telegram/TelegramHandlerTest.php
+++ b/tests/Unit/Telegram/TelegramHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Telegram;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\HttpFactory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Telegram\TelegramHandler;
 use MonologHttp\Tests\Unit\HandlerTestCase;
@@ -41,7 +41,7 @@ final class TelegramHandlerTest extends HandlerTestCase
     {
         return new TelegramHandler(
             $this->httpClient,
-            new Psr17Factory(),
+            new HttpFactory(),
             'TelegramApiKey',
             '1234'
         );

--- a/tests/Unit/Telegram/TelegramHandlerTest.php
+++ b/tests/Unit/Telegram/TelegramHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Telegram;
 
-use GuzzleHttp\Psr7\HttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Telegram\TelegramHandler;
 use MonologHttp\Tests\Unit\HandlerTestCase;
@@ -41,7 +41,7 @@ final class TelegramHandlerTest extends HandlerTestCase
     {
         return new TelegramHandler(
             $this->httpClient,
-            new HttpFactory(),
+            new Psr17Factory(),
             'TelegramApiKey',
             '1234'
         );

--- a/tests/Unit/Twilio/TwilioHandlerTest.php
+++ b/tests/Unit/Twilio/TwilioHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Twilio;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\HttpFactory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Tests\Unit\HandlerTestCase;
 use MonologHttp\Twilio\TwilioHandler;
@@ -38,7 +38,7 @@ final class TwilioHandlerTest extends HandlerTestCase
     {
         return new TwilioHandler(
             $this->httpClient,
-            new Psr17Factory(),
+            new HttpFactory(),
             'sid',
             'secret',
             '+35790909090',

--- a/tests/Unit/Twilio/TwilioHandlerTest.php
+++ b/tests/Unit/Twilio/TwilioHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MonologHttp\Tests\Unit\Twilio;
 
-use GuzzleHttp\Psr7\HttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Monolog\Handler\HandlerInterface;
 use MonologHttp\Tests\Unit\HandlerTestCase;
 use MonologHttp\Twilio\TwilioHandler;
@@ -38,7 +38,7 @@ final class TwilioHandlerTest extends HandlerTestCase
     {
         return new TwilioHandler(
             $this->httpClient,
-            new HttpFactory(),
+            new Psr17Factory(),
             'sid',
             'secret',
             '+35790909090',


### PR DESCRIPTION
This resolves #31  . Contrary to the initial issue description, using Nyholm's PSR-7 factory (as proposed in my fork) is not longer needed as Guzzle 1.7+ has added support for PHP 8 as well. 